### PR TITLE
Changed nob weapons

### DIFF
--- a/src/main/java/oc/wh40k/units/or/ORNobz.java
+++ b/src/main/java/oc/wh40k/units/or/ORNobz.java
@@ -35,6 +35,8 @@ public class ORNobz extends Eintrag {
 
         ogE.addElement(new OptionsGruppeEintrag("Kombi-rokkit", "Kombi-weapon with rokkit-launcha", getPts("Kombi-weapon with rokkit-launcha")));
         ogE.addElement(new OptionsGruppeEintrag("Kombi-skorcha", "Kombi-weapon with skorcha", getPts("Kombi-weapon with skorcha")));
+        ogE.addElement(new OptionsGruppeEintrag("Shoota [Index]", getPts("Shoota")));
+        ogE.addElement(new OptionsGruppeEintrag("Kustom shoota [Index]", getPts("Kustom shoota")));
         add(BosseFK = new OptionsZaehlerGruppe(ID, randAbstand, cnt, "", ogE, 1));
 
         seperator(5);
@@ -53,9 +55,9 @@ public class ORNobz extends Eintrag {
         BosseCC.setMaxAnzahl(Bosse.getModelle() * 2);
         BosseFK.setMaxAnzahl(Bosse.getModelle());
 
-        boolean legal = (BosseCC.getAnzahl() + BosseFK.getAnzahl() * 2) == Bosse.getModelle() * 2;
-        BosseCC.setLegal(legal);
-        BosseFK.setLegal(legal);
+//        boolean legal = (BosseCC.getAnzahl() + BosseFK.getAnzahl() * 2) == Bosse.getModelle() * 2;
+//        BosseCC.setLegal(legal);
+//        BosseFK.setLegal(legal);
 
         Munigrotz.setMaxAnzahl(Bosse.getModelle());
 

--- a/src/main/java/oc/wh40k/units/or/ORNobz.java
+++ b/src/main/java/oc/wh40k/units/or/ORNobz.java
@@ -55,10 +55,6 @@ public class ORNobz extends Eintrag {
         BosseCC.setMaxAnzahl(Bosse.getModelle() * 2);
         BosseFK.setMaxAnzahl(Bosse.getModelle());
 
-//        boolean legal = (BosseCC.getAnzahl() + BosseFK.getAnzahl() * 2) == Bosse.getModelle() * 2;
-//        BosseCC.setLegal(legal);
-//        BosseFK.setLegal(legal);
-
         Munigrotz.setMaxAnzahl(Bosse.getModelle());
 
         Cyborg.setMaxAnzahl(Bosse.getModelle() / 5);

--- a/src/main/java/oc/wh40k/units/or/ORNobzonWarbikes.java
+++ b/src/main/java/oc/wh40k/units/or/ORNobzonWarbikes.java
@@ -39,8 +39,8 @@ public class ORNobzonWarbikes extends Eintrag {
     //@OVERRIDE
     public void refreshen() {
         BosseCC.setMaxAnzahl(Bosse.getModelle() * 2);
-        boolean legal = (BosseCC.getAnzahl()) == Bosse.getModelle() * 2;
-        BosseCC.setLegal(legal);
+//        boolean legal = (BosseCC.getAnzahl()) == Bosse.getModelle() * 2;
+//        BosseCC.setLegal(legal);
 
         if (Bosse.getModelle() > 6) {
             power = 19;

--- a/src/main/java/oc/wh40k/units/or/ORNobzonWarbikes.java
+++ b/src/main/java/oc/wh40k/units/or/ORNobzonWarbikes.java
@@ -31,16 +31,12 @@ public class ORNobzonWarbikes extends Eintrag {
         BosseCC.setAnzahl(0, Bosse.getModelle());
         BosseCC.setAnzahl(5, Bosse.getModelle());
 
-        seperator(5);
-
         complete();
     }
 
     //@OVERRIDE
     public void refreshen() {
         BosseCC.setMaxAnzahl(Bosse.getModelle() * 2);
-//        boolean legal = (BosseCC.getAnzahl()) == Bosse.getModelle() * 2;
-//        BosseCC.setLegal(legal);
 
         if (Bosse.getModelle() > 6) {
             power = 19;

--- a/src/main/java/oc/wh40k/units/or/ORWaffenUndGeschenke.java
+++ b/src/main/java/oc/wh40k/units/or/ORWaffenUndGeschenke.java
@@ -280,6 +280,8 @@ public class ORWaffenUndGeschenke extends RuestkammerVater {
             if (!warbikerboss) {
                 ogE.addElement(new OptionsGruppeEintrag("Kombi-rokkit", "Kombi-weapon with rokkit-launcha", getPts("Kombi-weapon with rokkit-launcha")));
                 ogE.addElement(new OptionsGruppeEintrag("Kombi-skorcha", "Kombi-weapon with skorcha", getPts("Kombi-weapon with skorcha")));
+                ogE.addElement(new OptionsGruppeEintrag("Shoota [Index]", getPts("Shoota")));
+                ogE.addElement(new OptionsGruppeEintrag("Kustom shoota [Index]", getPts("Kustom shoota")));
                 add(BosseFK = new OptionsZaehlerGruppe(ID, randAbstand, cnt, "", ogE, 1));
             }
         }
@@ -319,22 +321,22 @@ public class ORWaffenUndGeschenke extends RuestkammerVater {
             gitstoppaShells.setAktiv((chosenRelic == null || gitstoppaShells.isSelected()) && (nkGitstoppa || fkGitstoppa));
         }
 
-        if (boyboss || warbikerboss) {
-
-            if (warbikerboss) {
-                BosseCC.setMaxAnzahl(2);
-
-                boolean legal = BosseCC.getAnzahl() == 2;
-                BosseCC.setLegal(legal);
-            } else {
-                if (BosseFK.isSelected()) BosseCC.setMaxAnzahl(0);
-                else BosseCC.setMaxAnzahl(2);
-
-                boolean legal = BosseFK.getAnzahl() * 2 + BosseCC.getAnzahl() == 2;
-                BosseFK.setLegal(legal);
-                BosseCC.setLegal(legal);
-            }
-        }
+//        if (boyboss || warbikerboss) {
+//
+//            if (warbikerboss) {
+//                BosseCC.setMaxAnzahl(2);
+//
+//                boolean legal = BosseCC.getAnzahl() == 2;
+//                BosseCC.setLegal(legal);
+//            } else {
+//                if (BosseFK.isSelected()) BosseCC.setMaxAnzahl(0);
+//                else BosseCC.setMaxAnzahl(2);
+//
+//                boolean legal = BosseFK.getAnzahl() * 2 + BosseCC.getAnzahl() == 2;
+//                BosseFK.setLegal(legal);
+//                BosseCC.setLegal(legal);
+//            }
+//        }
     }
 
 }

--- a/src/main/java/oc/wh40k/units/or/ORWaffenUndGeschenke.java
+++ b/src/main/java/oc/wh40k/units/or/ORWaffenUndGeschenke.java
@@ -320,23 +320,6 @@ public class ORWaffenUndGeschenke extends RuestkammerVater {
             
             gitstoppaShells.setAktiv((chosenRelic == null || gitstoppaShells.isSelected()) && (nkGitstoppa || fkGitstoppa));
         }
-
-//        if (boyboss || warbikerboss) {
-//
-//            if (warbikerboss) {
-//                BosseCC.setMaxAnzahl(2);
-//
-//                boolean legal = BosseCC.getAnzahl() == 2;
-//                BosseCC.setLegal(legal);
-//            } else {
-//                if (BosseFK.isSelected()) BosseCC.setMaxAnzahl(0);
-//                else BosseCC.setMaxAnzahl(2);
-//
-//                boolean legal = BosseFK.getAnzahl() * 2 + BosseCC.getAnzahl() == 2;
-//                BosseFK.setLegal(legal);
-//                BosseCC.setLegal(legal);
-//            }
-//        }
     }
 
 }


### PR DESCRIPTION
You can choose up to two CC weapons plus one kombi-weapon as
 maximum per boy. The possible minimum is zero weapons, as the
 nob weapons state 'up to' for both lists. With this change you
 can also build those old metal nobs with a kombi-weapon and choppa.
 
 Also added Shoota and Kustom shoota, following the designer's
  notes flowchart for missing item choices.