### PR TITLE
Fixed Runtherd Bugs

### DIFF
--- a/src/main/java/oc/Eintrag.java
+++ b/src/main/java/oc/Eintrag.java
@@ -96,13 +96,15 @@ public abstract class Eintrag extends OptionsCollection implements BuildaSTK {
                 if (uniqueError) {
                     setFehlermeldung("Doppeltes Relikt");
                 } else {
-                    setFehlermeldung("");
+                    setFehlermeldung(getFehlermeldung());
                 }
 
-                String fehlerBuffer = unikatFehler ? "" : getFehlermeldung();
                 if (unikat && oc.BuildaHQ.getCountFromInformationVectorGlobal(unikatName) > unikatMax) {
                     setFehlermeldung((unikatMin == unikatMax ? unikatMin : unikatMin + "-" + unikatMax) + " " + auswahl, true);
-                } else setFehlermeldung(fehlerBuffer);
+                } else {
+                	setFehlermeldung(getFehlermeldung());
+                }
+                
                 kostenLabelAktualisieren();
                 panel.setSize(getBreite(), getHöhe());
                 lKosten.setLocation(278, getHöhe() - 20);

--- a/src/main/java/oc/wh40k/units/or/ORGretchin.java
+++ b/src/main/java/oc/wh40k/units/or/ORGretchin.java
@@ -10,6 +10,8 @@ public class ORGretchin extends Eintrag {
     public ORGretchin() {
         kategorie = 3;
         grundkosten = 0;
+        
+        addToInformationVector("Gretchin Infantry", 1);
 
         add(squad = new AnzahlPanel(ID, randAbstand, cnt, "Gretchin", 10, 30, getPts("Gretchin")));
         add(ico = new oc.Picture("oc/wh40k/images/Grotz.gif"));
@@ -28,5 +30,10 @@ public class ORGretchin extends Eintrag {
         } else {
             power = 1;
         }
+    }
+    
+    @Override
+    public void deleteYourself(){
+        addToInformationVector("Gretchin Infantry", -1);
     }
 }

--- a/src/main/java/oc/wh40k/units/or/ORRuntherd.java
+++ b/src/main/java/oc/wh40k/units/or/ORRuntherd.java
@@ -4,12 +4,8 @@ import oc.Eintrag;
 import oc.OptionsGruppeEintrag;
 import oc.OptionsUpgradeGruppe;
 import oc.RuestkammerStarter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ORRuntherd extends Eintrag {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Eintrag.class);
     
     OptionsUpgradeGruppe o1 = null;
     OptionsUpgradeGruppe o2 = null;
@@ -52,8 +48,6 @@ public class ORRuntherd extends Eintrag {
 
     @Override
     public void refreshen() {
-    	LOGGER.error("" + getCountFromInformationVector("Runtherd"));
-    	LOGGER.error("" + getCountFromInformationVector("Gretchin Infantry"));
         o1.alwaysSelected();
         if(getCountFromInformationVector("Runtherd") > getCountFromInformationVector("Gretchin Infantry")){
         	setFehlermeldung("Zu wenig Gretchins!");

--- a/src/main/java/oc/wh40k/units/or/ORRuntherd.java
+++ b/src/main/java/oc/wh40k/units/or/ORRuntherd.java
@@ -4,9 +4,13 @@ import oc.Eintrag;
 import oc.OptionsGruppeEintrag;
 import oc.OptionsUpgradeGruppe;
 import oc.RuestkammerStarter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ORRuntherd extends Eintrag {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Eintrag.class);
+    
     OptionsUpgradeGruppe o1 = null;
     OptionsUpgradeGruppe o2 = null;
     RuestkammerStarter waffen;
@@ -16,7 +20,10 @@ public class ORRuntherd extends Eintrag {
         name = "Runtherd";
         grundkosten = getPts("Runtherd");
         power = 2;
+        setEintragsCNT(0.0);
 
+        addToInformationVector("Runtherd", 1);
+        
         add(ico = new oc.Picture("oc/wh40k/images/Runtherd.gif"));
 
 
@@ -45,7 +52,19 @@ public class ORRuntherd extends Eintrag {
 
     @Override
     public void refreshen() {
+    	LOGGER.error("" + getCountFromInformationVector("Runtherd"));
+    	LOGGER.error("" + getCountFromInformationVector("Gretchin Infantry"));
         o1.alwaysSelected();
+        if(getCountFromInformationVector("Runtherd") > getCountFromInformationVector("Gretchin Infantry")){
+        	setFehlermeldung("Zu wenig Gretchins!");
+        } else {
+        	setFehlermeldung("");
+        }
+    }
+    
+    @Override
+    public void deleteYourself(){
+        addToInformationVector("Runtherd", -1);
     }
 
 }


### PR DESCRIPTION
Runtherds do not take a slot now.
Runtherds show an error text, if there are not enough gretchin units.
Fixed error text handling in entries.

Fix issue #55 